### PR TITLE
Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ lto = true
 [dependencies]
 rand = "0.7"
 arrayvec = "0.5"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_repr = "0.1"
 
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ lto = true
 [dependencies]
 rand = "0.7"
 arrayvec = "0.5"
+serde_json = "1.0"
 
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -874,7 +874,7 @@ impl UCTMonteCarlo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Value;
+    use serde_json::{json, Value};
 
     #[test]
     fn possible_moves() {
@@ -925,6 +925,48 @@ mod tests {
             assert_eq!(stone3["x"].as_i64().unwrap(), s3.x as i64);
             assert_eq!(stone3["y"].as_i64().unwrap(), s3.y as i64);
             assert_eq!(color.as_i64().unwrap(), Color::Blue as i64);
+        }
+    }
+
+    #[test]
+    fn to_json() {
+        let mut board = Board::new(9);
+
+        board.apply_move(Move(Coord::new(0, 0), Coord::new(1, 1), Coord::new(1, 2)), Color::Red);
+        board.apply_move(Move(Coord::new(0, 8), Coord::new(1, 7), Coord::new(1, 6)), Color::Blue);
+
+        let board_from_json: Value = serde_json::from_str(&board.to_json()).unwrap();
+        let stones = &board_from_json["stones"].as_array().unwrap();
+        let roots = &board_from_json["roots"].as_array().unwrap();
+
+        assert_eq!(stones.len(), 8);
+        let correct_stones = vec![
+            json!({"x": 0, "y": 0, "color": Color::Red}),
+            json!({"x": 1, "y": 1, "color": Color::Red}),
+            json!({"x": 1, "y": 2, "color": Color::Red}),
+            json!({"x": 8, "y": 8, "color": Color::Red}),
+            json!({"x": 0, "y": 8, "color": Color::Blue}),
+            json!({"x": 1, "y": 7, "color": Color::Blue}),
+            json!({"x": 1, "y": 6, "color": Color::Blue}),
+            json!({"x": 8, "y": 0, "color": Color::Blue}),
+        ];
+        for correct in correct_stones {
+            assert!(stones.contains(&correct));
+        }
+
+        assert_eq!(roots.len(), 4*2);
+        let correct_roots = vec![
+            json!({"x1": 0, "y1": 0, "x2": 1, "y2": 1, "color": Color::Red}),
+            json!({"x1": 1, "y1": 1, "x2": 0, "y2": 0, "color": Color::Red}),
+            json!({"x1": 1, "y1": 1, "x2": 1, "y2": 2, "color": Color::Red}),
+            json!({"x1": 1, "y1": 2, "x2": 1, "y2": 1, "color": Color::Red}),
+            json!({"x1": 0, "y1": 8, "x2": 1, "y2": 7, "color": Color::Blue}),
+            json!({"x1": 1, "y1": 7, "x2": 0, "y2": 8, "color": Color::Blue}),
+            json!({"x1": 1, "y1": 7, "x2": 1, "y2": 6, "color": Color::Blue}),
+            json!({"x1": 1, "y1": 6, "x2": 1, "y2": 7, "color": Color::Blue}),
+        ];
+        for correct in correct_roots {
+            assert!(roots.contains(&correct));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,16 @@ macro_rules! console_log {
 // We will never use 256x256 board. The max size would be 19x19. u8 is enough.
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
-pub struct Coord (i8, i8);
+pub struct Coord {
+    x: i8,
+    y: i8,
+}
+
+impl Coord {
+    fn new(x: i8, y: i8) -> Self {
+        Self { x, y }
+    }
+}
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
@@ -111,7 +120,7 @@ impl Graph {
         // construct the whole graph
         for x in 0..ngrids as i8 {
             for y in 0..ngrids as i8 {
-                let crd = Coord(x, y);
+                let crd = Coord::new(x, y);
                 graph.at_mut(crd, NodePos::N).edges.push((crd, NodePos::E));
                 graph.at_mut(crd, NodePos::N).edges.push((crd, NodePos::W));
 
@@ -125,20 +134,20 @@ impl Graph {
                 graph.at_mut(crd, NodePos::W).edges.push((crd, NodePos::S));
 
                 if x != 0 {
-                    graph.at_mut(Coord(x,y), NodePos::W).edges
-                        .push((Coord(x-1,y), NodePos::E));
+                    graph.at_mut(Coord::new(x,y), NodePos::W).edges
+                        .push((Coord::new(x-1,y), NodePos::E));
                 }
                 if x != x_max {
-                    graph.at_mut(Coord(x,y), NodePos::E).edges
-                        .push((Coord(x+1,y), NodePos::W));
+                    graph.at_mut(Coord::new(x,y), NodePos::E).edges
+                        .push((Coord::new(x+1,y), NodePos::W));
                 }
                 if y != 0 {
-                    graph.at_mut(Coord(x,y), NodePos::N).edges
-                        .push((Coord(x,y-1), NodePos::S));
+                    graph.at_mut(Coord::new(x,y), NodePos::N).edges
+                        .push((Coord::new(x,y-1), NodePos::S));
                 }
                 if y != y_max {
-                    graph.at_mut(Coord(x,y), NodePos::S).edges
-                        .push((Coord(x,y+1), NodePos::N));
+                    graph.at_mut(Coord::new(x,y), NodePos::S).edges
+                        .push((Coord::new(x,y+1), NodePos::N));
                 }
             }
         }
@@ -150,23 +159,23 @@ impl Graph {
         let Move(stone1, stone2, stone3) = next_move;
 
         // first root
-        let dx = stone2.0 - stone1.0;
-        let dy = stone2.1 - stone1.1;
+        let dx = stone2.x - stone1.x;
+        let dy = stone2.y - stone1.y;
         match (dx, dy) {
             (1, 1) => {
                 self.remove_edge(stone1, NodePos::N, stone1, NodePos::W);
                 self.remove_edge(stone1, NodePos::S, stone1, NodePos::E);
             }
             (1, -1) => {
-                let pos = Coord(stone1.0, stone1.1 - 1);
-                if 0 <= pos.1 {
+                let pos = Coord::new(stone1.x, stone1.y - 1);
+                if 0 <= pos.y {
                     self.remove_edge(pos, NodePos::N, pos, NodePos::E);
                     self.remove_edge(pos, NodePos::S, pos, NodePos::W);
                 }
             }
             (-1, 1) => {
-                let pos = Coord(stone1.0 - 1, stone1.1);
-                if 0 <= pos.0 {
+                let pos = Coord::new(stone1.x - 1, stone1.y);
+                if 0 <= pos.x {
                     self.remove_edge(pos, NodePos::N, pos, NodePos::E);
                     self.remove_edge(pos, NodePos::S, pos, NodePos::W);
                 }
@@ -180,33 +189,33 @@ impl Graph {
             }
         }
         // second root
-        let dx = stone3.0 - stone2.0;
-        let dy = stone3.1 - stone2.1;
+        let dx = stone3.x - stone2.x;
+        let dy = stone3.y - stone2.y;
 
         let upper = self.ngrids as i8;
         match (dx, dy) {
             (1, 0) => {
-                if stone2.0 < upper && 1 <= stone2.1 && stone2.1 < upper {
-                    self.remove_edge(Coord(stone2.0, stone2.1-1), NodePos::S,
-                                           stone2,                NodePos::N);
+                if stone2.x < upper && 1 <= stone2.y && stone2.y < upper {
+                    self.remove_edge(Coord::new(stone2.x, stone2.y-1), NodePos::S,
+                                                stone2,                NodePos::N);
                 }
             }
             (-1, 0) => {
-                if stone3.0 < upper && 1 <= stone3.1 && stone3.1 < upper {
-                    self.remove_edge(Coord(stone3.0, stone3.1-1), NodePos::S,
-                                           stone3,                NodePos::N);
+                if stone3.x < upper && 1 <= stone3.y && stone3.y < upper {
+                    self.remove_edge(Coord::new(stone3.x, stone3.y-1), NodePos::S,
+                                                stone3,                NodePos::N);
                 }
             }
             (0, 1) => {
-                if 1 <= stone2.0 && stone2.0 < upper && stone2.1 < upper {
-                    self.remove_edge(Coord(stone2.0-1, stone2.1), NodePos::E,
-                                           stone2,                NodePos::W);
+                if 1 <= stone2.x && stone2.x < upper && stone2.y < upper {
+                    self.remove_edge(Coord::new(stone2.x-1, stone2.y), NodePos::E,
+                                                stone2,                NodePos::W);
                 }
             }
             (0, -1) => {
-                if 1 <= stone3.0 && stone3.0 < upper && stone3.1 < upper {
-                    self.remove_edge(Coord(stone3.0-1, stone3.1), NodePos::E,
-                                           stone3,                NodePos::W);
+                if 1 <= stone3.x && stone3.x < upper && stone3.y < upper {
+                    self.remove_edge(Coord::new(stone3.x-1, stone3.y), NodePos::E,
+                                                stone3,                NodePos::W);
                 }
             }
             _ => {
@@ -235,7 +244,7 @@ impl Graph {
             assert!(x <= i8::MAX as usize);
             assert!(y <= i8::MAX as usize);
 
-            let crd = Coord(x as i8, y as i8);
+            let crd = Coord::new(x as i8, y as i8);
             if 4 < self.find_connected_component(region, crd, pos) {
                 score += 1;
             }
@@ -271,8 +280,8 @@ impl Graph {
     }
 
     fn at(&self, coord: Coord, pos: NodePos) -> &Node {
-        let idx = ((coord.0 as usize) * (self.ngrids as usize) +
-                   (coord.1 as usize)) * 4 + match pos {
+        let idx = ((coord.x as usize) * (self.ngrids as usize) +
+                   (coord.y as usize)) * 4 + match pos {
             NodePos::N => 0,
             NodePos::E => 1,
             NodePos::S => 2,
@@ -282,8 +291,8 @@ impl Graph {
         &self.nodes[idx]
     }
     fn at_mut(&mut self, coord: Coord, pos: NodePos) -> &mut Node {
-        let idx = ((coord.0 as usize) * (self.ngrids as usize) +
-                   (coord.1 as usize)) * 4 + match pos {
+        let idx = ((coord.x as usize) * (self.ngrids as usize) +
+                   (coord.y as usize)) * 4 + match pos {
             NodePos::N => 0,
             NodePos::E => 1,
             NodePos::S => 2,
@@ -409,7 +418,7 @@ impl Board {
                             let idx3 = x3 as usize * self.width as usize + y3 as usize;
                             if (self.grids[idx3].color == None || self.grids[idx3].color == Some(turn)) &&
                                 self.grids[idx3].is_valid_root(Dir(-dir2.0, -dir2.1)) {
-                                moves.push(Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3)));
+                                moves.push(Move(Coord::new(x1, y1), Coord::new(x2, y2), Coord::new(x3, y3)));
                             }
                         }
                     }
@@ -427,7 +436,7 @@ impl Board {
                             let idx3 = x3 as usize * self.width as usize + y3 as usize;
                             if (self.grids[idx3].color == None || self.grids[idx3].color == Some(turn)) &&
                                 self.grids[idx3].is_valid_root(Dir(-dir2.0, -dir2.1)) {
-                                moves.push(Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3)));
+                                moves.push(Move(Coord::new(x1, y1), Coord::new(x2, y2), Coord::new(x3, y3)));
                             }
                         }
                     }
@@ -440,9 +449,9 @@ impl Board {
     pub fn apply_move_if_possible(&mut self,
         x1: i32, y1: i32, x2: i32, y2: i32, x3: i32, y3: i32, color: Color
         ) -> bool {
-        let next_move = Move(Coord(x1 as i8, y1 as i8),
-                             Coord(x2 as i8, y2 as i8),
-                             Coord(x3 as i8, y3 as i8));
+        let next_move = Move(Coord::new(x1 as i8, y1 as i8),
+                             Coord::new(x2 as i8, y2 as i8),
+                             Coord::new(x3 as i8, y3 as i8));
         if self.is_valid_move(next_move, color) {
             self.apply_move(next_move, color);
             true
@@ -470,18 +479,18 @@ impl Board {
 
         let Move(stone1, stone2, stone3) = next_move;
 
-        let idx1 = stone1.0 as usize * self.width as usize + stone1.1 as usize;
-        let idx2 = stone2.0 as usize * self.width as usize + stone2.1 as usize;
-        let idx3 = stone3.0 as usize * self.width as usize + stone3.1 as usize;
+        let idx1 = stone1.x as usize * self.width as usize + stone1.y as usize;
+        let idx2 = stone2.x as usize * self.width as usize + stone2.y as usize;
+        let idx3 = stone3.x as usize * self.width as usize + stone3.y as usize;
 
         self.grids[idx2].color = Some(turn);
         self.grids[idx3].color = Some(turn);
 
-        self.grids[idx1].roots.push(Dir(stone2.0 - stone1.0, stone2.1 - stone1.1));
-        self.grids[idx2].roots.push(Dir(stone1.0 - stone2.0, stone1.1 - stone2.1));
+        self.grids[idx1].roots.push(Dir(stone2.x - stone1.x, stone2.y - stone1.y));
+        self.grids[idx2].roots.push(Dir(stone1.x - stone2.x, stone1.y - stone2.y));
 
-        self.grids[idx2].roots.push(Dir(stone3.0 - stone2.0, stone3.1 - stone2.1));
-        self.grids[idx3].roots.push(Dir(stone2.0 - stone3.0, stone2.1 - stone3.1));
+        self.grids[idx2].roots.push(Dir(stone3.x - stone2.x, stone3.y - stone2.y));
+        self.grids[idx3].roots.push(Dir(stone2.x - stone3.x, stone2.y - stone3.y));
 
         // apply next_move to internal graph
         match turn {
@@ -872,10 +881,10 @@ mod tests {
         let board = Board::new(9);
         let possibles = board.possible_moves(Color::Red);
         assert_eq!(possibles.len(), 4);
-        assert!(possibles.contains(&Move(Coord(0, 0), Coord(1, 1), Coord(1, 2))));
-        assert!(possibles.contains(&Move(Coord(0, 0), Coord(1, 1), Coord(2, 1))));
-        assert!(possibles.contains(&Move(Coord(8, 8), Coord(7, 7), Coord(7, 6))));
-        assert!(possibles.contains(&Move(Coord(8, 8), Coord(7, 7), Coord(6, 7))));
+        assert!(possibles.contains(&Move(Coord::new(0, 0), Coord::new(1, 1), Coord::new(1, 2))));
+        assert!(possibles.contains(&Move(Coord::new(0, 0), Coord::new(1, 1), Coord::new(2, 1))));
+        assert!(possibles.contains(&Move(Coord::new(8, 8), Coord::new(7, 7), Coord::new(7, 6))));
+        assert!(possibles.contains(&Move(Coord::new(8, 8), Coord::new(7, 7), Coord::new(6, 7))));
     }
 
     #[test]
@@ -887,35 +896,35 @@ mod tests {
 
         let moves_from_json: Value = serde_json::from_str(&board.possible_moves_as_json()).unwrap();
 
-        for (i, Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3))) in red_moves.iter().enumerate() {
+        for (i, Move(s1, s2, s3)) in red_moves.iter().enumerate() {
             let stone1 = &moves_from_json[i]["stones"][0];
             let stone2 = &moves_from_json[i]["stones"][1];
             let stone3 = &moves_from_json[i]["stones"][2];
             let color = &moves_from_json[i]["color"];
 
-            assert_eq!(stone1[0].as_i64().unwrap(), *x1 as i64);
-            assert_eq!(stone1[1].as_i64().unwrap(), *y1 as i64);
-            assert_eq!(stone2[0].as_i64().unwrap(), *x2 as i64);
-            assert_eq!(stone2[1].as_i64().unwrap(), *y2 as i64);
-            assert_eq!(stone3[0].as_i64().unwrap(), *x3 as i64);
-            assert_eq!(stone3[1].as_i64().unwrap(), *y3 as i64);
-            assert_eq!(color.as_i64().unwrap(), 0);
+            assert_eq!(stone1["x"].as_i64().unwrap(), s1.x as i64);
+            assert_eq!(stone1["y"].as_i64().unwrap(), s1.y as i64);
+            assert_eq!(stone2["x"].as_i64().unwrap(), s2.x as i64);
+            assert_eq!(stone2["y"].as_i64().unwrap(), s2.y as i64);
+            assert_eq!(stone3["x"].as_i64().unwrap(), s3.x as i64);
+            assert_eq!(stone3["y"].as_i64().unwrap(), s3.y as i64);
+            assert_eq!(color.as_i64().unwrap(), Color::Red as i64);
         }
 
-        for (i, Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3))) in blue_moves.iter().enumerate() {
+        for (i, Move(s1, s2, s3)) in blue_moves.iter().enumerate() {
             let i = i + red_moves.len();
             let stone1 = &moves_from_json[i]["stones"][0];
             let stone2 = &moves_from_json[i]["stones"][1];
             let stone3 = &moves_from_json[i]["stones"][2];
             let color = &moves_from_json[i]["color"];
 
-            assert_eq!(stone1[0].as_i64().unwrap(), *x1 as i64);
-            assert_eq!(stone1[1].as_i64().unwrap(), *y1 as i64);
-            assert_eq!(stone2[0].as_i64().unwrap(), *x2 as i64);
-            assert_eq!(stone2[1].as_i64().unwrap(), *y2 as i64);
-            assert_eq!(stone3[0].as_i64().unwrap(), *x3 as i64);
-            assert_eq!(stone3[1].as_i64().unwrap(), *y3 as i64);
-            assert_eq!(color.as_i64().unwrap(), 1);
+            assert_eq!(stone1["x"].as_i64().unwrap(), s1.x as i64);
+            assert_eq!(stone1["y"].as_i64().unwrap(), s1.y as i64);
+            assert_eq!(stone2["x"].as_i64().unwrap(), s2.x as i64);
+            assert_eq!(stone2["y"].as_i64().unwrap(), s2.y as i64);
+            assert_eq!(stone3["x"].as_i64().unwrap(), s3.x as i64);
+            assert_eq!(stone3["y"].as_i64().unwrap(), s3.y as i64);
+            assert_eq!(color.as_i64().unwrap(), Color::Blue as i64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -856,3 +856,59 @@ impl UCTMonteCarlo {
         self.root.borrow().board.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn possible_moves() {
+        let board = Board::new(9);
+        let possibles = board.possible_moves(Color::Red);
+        assert_eq!(possibles.len(), 4);
+        assert!(possibles.contains(&Move(Coord(0, 0), Coord(1, 1), Coord(1, 2))));
+        assert!(possibles.contains(&Move(Coord(0, 0), Coord(1, 1), Coord(2, 1))));
+        assert!(possibles.contains(&Move(Coord(8, 8), Coord(7, 7), Coord(7, 6))));
+        assert!(possibles.contains(&Move(Coord(8, 8), Coord(7, 7), Coord(6, 7))));
+    }
+
+    #[test]
+    fn possible_moves_as_json() {
+        let board = Board::new(9);
+
+        let red_moves = board.possible_moves(Color::Red);
+        let blue_moves = board.possible_moves(Color::Blue);
+
+        let moves_from_json: Value = serde_json::from_str(&board.possible_moves_as_json()).unwrap();
+
+        for (i, Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3))) in red_moves.iter().enumerate() {
+            assert_eq!(moves_from_json[i*2]["x1"].as_i64().unwrap(), *x1 as i64);
+            assert_eq!(moves_from_json[i*2]["y1"].as_i64().unwrap(), *y1 as i64);
+            assert_eq!(moves_from_json[i*2]["x2"].as_i64().unwrap(), *x2 as i64);
+            assert_eq!(moves_from_json[i*2]["y2"].as_i64().unwrap(), *y2 as i64);
+            assert_eq!(moves_from_json[i*2]["color"].as_i64().unwrap(), 0);
+
+            assert_eq!(moves_from_json[i*2+1]["x1"].as_i64().unwrap(), *x2 as i64);
+            assert_eq!(moves_from_json[i*2+1]["y1"].as_i64().unwrap(), *y2 as i64);
+            assert_eq!(moves_from_json[i*2+1]["x2"].as_i64().unwrap(), *x3 as i64);
+            assert_eq!(moves_from_json[i*2+1]["y2"].as_i64().unwrap(), *y3 as i64);
+            assert_eq!(moves_from_json[i*2+1]["color"].as_i64().unwrap(), 0);
+        }
+
+        for (i, Move(Coord(x1, y1), Coord(x2, y2), Coord(x3, y3))) in blue_moves.iter().enumerate() {
+            let i = i + red_moves.len();
+            assert_eq!(moves_from_json[i*2]["x1"].as_i64().unwrap(), *x1 as i64);
+            assert_eq!(moves_from_json[i*2]["y1"].as_i64().unwrap(), *y1 as i64);
+            assert_eq!(moves_from_json[i*2]["x2"].as_i64().unwrap(), *x2 as i64);
+            assert_eq!(moves_from_json[i*2]["y2"].as_i64().unwrap(), *y2 as i64);
+            assert_eq!(moves_from_json[i*2]["color"].as_i64().unwrap(), 1);
+
+            assert_eq!(moves_from_json[i*2+1]["x1"].as_i64().unwrap(), *x2 as i64);
+            assert_eq!(moves_from_json[i*2+1]["y1"].as_i64().unwrap(), *y2 as i64);
+            assert_eq!(moves_from_json[i*2+1]["x2"].as_i64().unwrap(), *x3 as i64);
+            assert_eq!(moves_from_json[i*2+1]["y2"].as_i64().unwrap(), *y3 as i64);
+            assert_eq!(moves_from_json[i*2+1]["color"].as_i64().unwrap(), 1);
+        }
+    }
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -281,8 +281,14 @@ function drawBoard(context, board, red_name, blue_name, msg) {
 
     if(draw_guide) {
         JSON.parse(board.possible_moves_as_json()).forEach(function(root) {
-            drawTemporaryRoot(context, root["x1"], root["y1"],
-                                       root["x2"], root["y2"], root["color"]);
+            let stone1 = root["stones"][0];
+            let stone2 = root["stones"][1];
+            let stone3 = root["stones"][2];
+            let color = root["color"];
+            drawTemporaryRoot(context, stone1[0], stone1[1],
+                                       stone2[0], stone2[1], color);
+            drawTemporaryRoot(context, stone2[0], stone2[1],
+                                       stone3[0], stone3[1], color);
         });
     }
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -285,10 +285,10 @@ function drawBoard(context, board, red_name, blue_name, msg) {
             let stone2 = root["stones"][1];
             let stone3 = root["stones"][2];
             let color = root["color"];
-            drawTemporaryRoot(context, stone1[0], stone1[1],
-                                       stone2[0], stone2[1], color);
-            drawTemporaryRoot(context, stone2[0], stone2[1],
-                                       stone3[0], stone3[1], color);
+            drawTemporaryRoot(context, stone1["x"], stone1["y"],
+                                       stone2["x"], stone2["y"], color);
+            drawTemporaryRoot(context, stone2["x"], stone2["y"],
+                                       stone3["x"], stone3["y"], color);
         });
     }
 }


### PR DESCRIPTION
It is too complicated to maintain JSON outputs implemented explicitly.
This PR, therefore, introduces a `serde` dependency for JSON outputs.

This PR also makes a change of an API changes of `Board::possible_moves_as_json()`.
It returns JSON string with the below form:

```json
[
    {
        "stones": [
             {"x": 0, "y": 0},
             {"x": 1, "y": 1},
             {"x": 1, "y": 2},
        ],
        "color": 0,
    },
    ...
]
```