### PR TITLE
Drop gif_encoder before dumping data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,7 +940,8 @@ impl GameGifEncoder {
         self.gif_encoder.as_mut().unwrap().write_frame(&frame).unwrap();
     }
 
-    pub fn dump(&self) -> String {
+    pub fn dump(&mut self) -> String {
+        self.gif_encoder = None; // drop gif_encoder
         base64::encode(&*self.gif_buffer.borrow())
     }
 }


### PR DESCRIPTION
`gif::Encoder` implements `Drop` trait for finalizing the Encode process, this PR, therefore, ensures that `Encoder` is dropped and finalized before dumping data.